### PR TITLE
Card collection feature

### DIFF
--- a/backend/src/main/java/de/christianporsch/backend/controller/CardPileController.java
+++ b/backend/src/main/java/de/christianporsch/backend/controller/CardPileController.java
@@ -1,0 +1,33 @@
+package de.christianporsch.backend.controller;
+
+import de.christianporsch.backend.model.MagicCard;
+import de.christianporsch.backend.service.CardPileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/api/cardsInPile")
+public class CardPileController {
+
+    private final CardPileService cardPileService;
+
+    @Autowired
+    public CardPileController(CardPileService cardPileService) {
+        this.cardPileService = cardPileService;
+    }
+
+    @GetMapping("{id}")
+    public List<MagicCard> findPileOfCardsByUser(@PathVariable String id){
+        List<MagicCard> response = cardPileService.findPileOfCardsByUser(id);
+        return response;
+    }
+
+
+}

--- a/backend/src/main/java/de/christianporsch/backend/controller/CardPileController.java
+++ b/backend/src/main/java/de/christianporsch/backend/controller/CardPileController.java
@@ -9,8 +9,10 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @RestController
@@ -27,7 +29,10 @@ public class CardPileController {
     @GetMapping("{id}")
     public List<MagicCardInPile> findPileOfCardsByUser(@PathVariable String id) {
         List<MagicCardInPile> response = cardPileService.findPileOfCardsByUser(id);
-        return response;
+        return response
+                .stream()
+                .sorted(Comparator.comparing(MagicCardInPile::getName))
+                .collect(Collectors.toList());
     }
 
     @GetMapping("/userPile/{id}")

--- a/backend/src/main/java/de/christianporsch/backend/controller/CardPileController.java
+++ b/backend/src/main/java/de/christianporsch/backend/controller/CardPileController.java
@@ -1,13 +1,16 @@
 package de.christianporsch.backend.controller;
 
-import de.christianporsch.backend.model.MagicCard;
+import de.christianporsch.backend.model.MagicCardInPile;
 import de.christianporsch.backend.model.dto.MagicCardDto;
 import de.christianporsch.backend.service.CardPileService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 
 import java.util.List;
+import java.util.Optional;
 
 
 @RestController
@@ -22,14 +25,23 @@ public class CardPileController {
     }
 
     @GetMapping("{id}")
-    public List<MagicCard> findPileOfCardsByUser(@PathVariable String id) {
-        List<MagicCard> response = cardPileService.findPileOfCardsByUser(id);
+    public List<MagicCardInPile> findPileOfCardsByUser(@PathVariable String id) {
+        List<MagicCardInPile> response = cardPileService.findPileOfCardsByUser(id);
         return response;
     }
 
+    @GetMapping("/userPile/{id}")
+    public MagicCardInPile findMagicCardInPileById (@PathVariable String id){
+        Optional<MagicCardInPile> response = cardPileService.findMagicCardInPileById(id);
+        if (response.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Magic card with id " + id + " not found");
+        }
+        return response.get();
+    }
+
     @PostMapping
-    public MagicCard addMagicCardToPile(@RequestBody MagicCardDto magicCardToAdd) {
-        return cardPileService.addMagicCardToPile(magicCardToAdd);
+    public void addMagicCardToPile(@RequestBody MagicCardDto magicCardToAdd) {
+        cardPileService.addMagicCardToPile(magicCardToAdd);
     }
 
 

--- a/backend/src/main/java/de/christianporsch/backend/controller/CardPileController.java
+++ b/backend/src/main/java/de/christianporsch/backend/controller/CardPileController.java
@@ -22,15 +22,16 @@ public class CardPileController {
     }
 
     @GetMapping("{id}")
-    public List<MagicCard> findPileOfCardsByUser(@PathVariable String id){
+    public List<MagicCard> findPileOfCardsByUser(@PathVariable String id) {
         List<MagicCard> response = cardPileService.findPileOfCardsByUser(id);
         return response;
     }
 
     @PostMapping
-    public MagicCard addMagicCardToPile(@RequestBody MagicCardDto magicCardToAdd){
+    public MagicCard addMagicCardToPile(@RequestBody MagicCardDto magicCardToAdd) {
         return cardPileService.addMagicCardToPile(magicCardToAdd);
-
     }
+
+
 
 }

--- a/backend/src/main/java/de/christianporsch/backend/controller/CardPileController.java
+++ b/backend/src/main/java/de/christianporsch/backend/controller/CardPileController.java
@@ -1,12 +1,10 @@
 package de.christianporsch.backend.controller;
 
 import de.christianporsch.backend.model.MagicCard;
+import de.christianporsch.backend.model.dto.MagicCardDto;
 import de.christianporsch.backend.service.CardPileService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 import java.util.List;
@@ -29,5 +27,10 @@ public class CardPileController {
         return response;
     }
 
+    @PostMapping
+    public MagicCard addMagicCardToPile(@RequestBody MagicCardDto magicCardToAdd){
+        return cardPileService.addMagicCardToPile(magicCardToAdd);
+
+    }
 
 }

--- a/backend/src/main/java/de/christianporsch/backend/model/MagicCard.java
+++ b/backend/src/main/java/de/christianporsch/backend/model/MagicCard.java
@@ -17,6 +17,7 @@ public class MagicCard {
     private String name;
     private String oracle_text;
     private CardImage image_uris;
+    private String set_name;
     private Price prices;
 
 }

--- a/backend/src/main/java/de/christianporsch/backend/model/MagicCardInPile.java
+++ b/backend/src/main/java/de/christianporsch/backend/model/MagicCardInPile.java
@@ -1,23 +1,25 @@
 package de.christianporsch.backend.model;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
-
-import java.util.List;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Document(collection = "user")
-public class User {
+@Builder
+@Document(collection = "magiccardsinpile")
+public class MagicCardInPile {
 
     @Id
     private String id;
-    private String username;
-    @DBRef
-    private List<MagicCardInPile> pileOfCards;
+    private String name;
+    private String oracle_text;
+    private CardImage image_uris;
+    private int amount;
+    private boolean priceAlert;
+
 }

--- a/backend/src/main/java/de/christianporsch/backend/model/MagicCardInPile.java
+++ b/backend/src/main/java/de/christianporsch/backend/model/MagicCardInPile.java
@@ -19,6 +19,7 @@ public class MagicCardInPile {
     private String name;
     private String oracle_text;
     private CardImage image_uris;
+    private String set_name;
     private int amount;
     private boolean priceAlert;
 

--- a/backend/src/main/java/de/christianporsch/backend/model/User.java
+++ b/backend/src/main/java/de/christianporsch/backend/model/User.java
@@ -1,0 +1,23 @@
+package de.christianporsch.backend.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(collection = "user")
+public class User {
+
+    @Id
+    private String id;
+    private String username;
+    @DBRef
+    private List<MagicCard> pileOfCards;
+}

--- a/backend/src/main/java/de/christianporsch/backend/model/dto/MagicCardDto.java
+++ b/backend/src/main/java/de/christianporsch/backend/model/dto/MagicCardDto.java
@@ -1,0 +1,13 @@
+package de.christianporsch.backend.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MagicCardDto {
+
+    private String id;
+}

--- a/backend/src/main/java/de/christianporsch/backend/repository/MagicCardInPileRepository.java
+++ b/backend/src/main/java/de/christianporsch/backend/repository/MagicCardInPileRepository.java
@@ -1,0 +1,14 @@
+package de.christianporsch.backend.repository;
+
+import de.christianporsch.backend.model.MagicCardInPile;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MagicCardInPileRepository extends PagingAndSortingRepository<MagicCardInPile, String> {
+
+    Optional<MagicCardInPile> findMagicCardInPileById(String id);
+
+}

--- a/backend/src/main/java/de/christianporsch/backend/repository/UserPileRepository.java
+++ b/backend/src/main/java/de/christianporsch/backend/repository/UserPileRepository.java
@@ -1,6 +1,5 @@
 package de.christianporsch.backend.repository;
 
-import de.christianporsch.backend.model.MagicCard;
 import de.christianporsch.backend.model.User;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;

--- a/backend/src/main/java/de/christianporsch/backend/repository/UserPileRepository.java
+++ b/backend/src/main/java/de/christianporsch/backend/repository/UserPileRepository.java
@@ -1,0 +1,14 @@
+package de.christianporsch.backend.repository;
+
+import de.christianporsch.backend.model.MagicCard;
+import de.christianporsch.backend.model.User;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+
+
+
+@Repository
+public interface UserPileRepository extends PagingAndSortingRepository<User, String> {
+
+    User findUserById(String id);
+}

--- a/backend/src/main/java/de/christianporsch/backend/repository/UserRepository.java
+++ b/backend/src/main/java/de/christianporsch/backend/repository/UserRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 
 
 @Repository
-public interface UserPileRepository extends PagingAndSortingRepository<User, String> {
+public interface UserRepository extends PagingAndSortingRepository<User, String> {
 
     User findUserById(String id);
 }

--- a/backend/src/main/java/de/christianporsch/backend/service/CardPileService.java
+++ b/backend/src/main/java/de/christianporsch/backend/service/CardPileService.java
@@ -1,39 +1,67 @@
 package de.christianporsch.backend.service;
 
 import de.christianporsch.backend.model.MagicCard;
+import de.christianporsch.backend.model.MagicCardInPile;
 import de.christianporsch.backend.model.User;
 import de.christianporsch.backend.model.dto.MagicCardDto;
-import de.christianporsch.backend.repository.UserPileRepository;
+import de.christianporsch.backend.repository.MagicCardInPileRepository;
+import de.christianporsch.backend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Optional;
 
+
 @Service
 public class CardPileService {
 
-    private final UserPileRepository userPileRepository;
+    private final UserRepository userRepository;
+    private final MagicCardInPileRepository magicCardInPileRepository;
     private final CardSearchService cardSearchService;
 
+
     @Autowired
-    public CardPileService(UserPileRepository userPileRepository, CardSearchService cardSearchService) {
-        this.userPileRepository = userPileRepository;
+    public CardPileService(UserRepository userRepository, MagicCardInPileRepository magicCardInPileRepository, CardSearchService cardSearchService) {
+        this.userRepository = userRepository;
+        this.magicCardInPileRepository = magicCardInPileRepository;
         this.cardSearchService = cardSearchService;
     }
 
-    public List<MagicCard> findPileOfCardsByUser(String id) {
-        return userPileRepository.findUserById(id).getPileOfCards();
+    public List<MagicCardInPile> findPileOfCardsByUser(String id) {
+        return userRepository.findUserById(id).getPileOfCards();
     }
 
-    public MagicCard addMagicCardToPile(MagicCardDto magicCardToAdd) {
+    public Optional<MagicCardInPile> findMagicCardInPileById (String id){
+        return magicCardInPileRepository.findMagicCardInPileById(id);
+    }
+
+    public void addMagicCardToPile(MagicCardDto magicCardToAdd) {
         Optional<MagicCard> magicCard = cardSearchService.findMagicCardById(magicCardToAdd.getId());
+
         if (magicCard.isPresent()) {
-            User user = userPileRepository.findUserById("60d2f120c76f8707f38e9a99");
-            user.getPileOfCards().add(magicCard.get());
-            userPileRepository.save(user);
+            User user = userRepository.findUserById("60d2f120c76f8707f38e9a99");
+            Optional<MagicCardInPile> magicCardInPile = user.getPileOfCards().stream().filter((card) -> magicCard.get().getId().equals(card.getId())).findFirst();
+            if(magicCardInPile.isPresent()){
+                magicCardInPile.get().setAmount(magicCardInPile.get().getAmount()+1);
+                magicCardInPileRepository.save(magicCardInPile.get());
+            }
+            else {
+                MagicCardInPile newMagicCardInPile = MagicCardInPile.builder()
+                        .id(magicCard.get().getId())
+                        .amount(1)
+                        .name(magicCard.get().getName())
+                        .oracle_text(magicCard.get().getOracle_text())
+                        .image_uris(magicCard.get().getImage_uris())
+                        .build();
+                user.getPileOfCards().add(newMagicCardInPile);
+                magicCardInPileRepository.save(newMagicCardInPile);
+            }
+            userRepository.save(user);
         }
-        return magicCard.get();
+         else {throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Error");}
     }
 
 

--- a/backend/src/main/java/de/christianporsch/backend/service/CardPileService.java
+++ b/backend/src/main/java/de/christianporsch/backend/service/CardPileService.java
@@ -1,0 +1,25 @@
+package de.christianporsch.backend.service;
+
+import de.christianporsch.backend.model.MagicCard;
+import de.christianporsch.backend.repository.UserPileRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CardPileService {
+
+    private final UserPileRepository userPileRepository;
+
+    @Autowired
+    public CardPileService(UserPileRepository userPileRepository) {
+        this.userPileRepository = userPileRepository;
+    }
+
+    public List<MagicCard> findPileOfCardsByUser(String id){
+        return userPileRepository.findUserById(id).getPileOfCards();
+    }
+
+
+}

--- a/backend/src/main/java/de/christianporsch/backend/service/CardPileService.java
+++ b/backend/src/main/java/de/christianporsch/backend/service/CardPileService.java
@@ -55,6 +55,7 @@ public class CardPileService {
                         .name(magicCard.get().getName())
                         .oracle_text(magicCard.get().getOracle_text())
                         .image_uris(magicCard.get().getImage_uris())
+                        .set_name(magicCard.get().getSet_name())
                         .build();
                 user.getPileOfCards().add(newMagicCardInPile);
                 magicCardInPileRepository.save(newMagicCardInPile);

--- a/backend/src/main/java/de/christianporsch/backend/service/CardPileService.java
+++ b/backend/src/main/java/de/christianporsch/backend/service/CardPileService.java
@@ -1,24 +1,39 @@
 package de.christianporsch.backend.service;
 
 import de.christianporsch.backend.model.MagicCard;
+import de.christianporsch.backend.model.User;
+import de.christianporsch.backend.model.dto.MagicCardDto;
 import de.christianporsch.backend.repository.UserPileRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class CardPileService {
 
     private final UserPileRepository userPileRepository;
+    private final CardSearchService cardSearchService;
 
     @Autowired
-    public CardPileService(UserPileRepository userPileRepository) {
+    public CardPileService(UserPileRepository userPileRepository, CardSearchService cardSearchService) {
         this.userPileRepository = userPileRepository;
+        this.cardSearchService = cardSearchService;
     }
 
-    public List<MagicCard> findPileOfCardsByUser(String id){
+    public List<MagicCard> findPileOfCardsByUser(String id) {
         return userPileRepository.findUserById(id).getPileOfCards();
+    }
+
+    public MagicCard addMagicCardToPile(MagicCardDto magicCardToAdd) {
+        Optional<MagicCard> magicCard = cardSearchService.findMagicCardById(magicCardToAdd.getId());
+        if (magicCard.isPresent()) {
+            User user = userPileRepository.findUserById("60d2f120c76f8707f38e9a99");
+            user.getPileOfCards().add(magicCard.get());
+            userPileRepository.save(user);
+        }
+        return magicCard.get();
     }
 
 

--- a/backend/src/main/java/de/christianporsch/backend/service/CardSearchService.java
+++ b/backend/src/main/java/de/christianporsch/backend/service/CardSearchService.java
@@ -27,4 +27,5 @@ public class CardSearchService {
         return magicCardRepository.findMagicCardById(id);
     }
 
+
 }

--- a/backend/src/test/java/de/christianporsch/backend/controller/CardSearchControllerTest.java
+++ b/backend/src/test/java/de/christianporsch/backend/controller/CardSearchControllerTest.java
@@ -35,8 +35,8 @@ class CardSearchControllerTest {
 
         // Given
 
-        magicCardRepository.save(new MagicCard("1","Tarmogoyf", "some oracle text about tarmo", new CardImage("tarmoHighresImg"), new Price(10, 20, 15)));
-        magicCardRepository.save(new MagicCard("2","Jace, the Mindsculptor", "some oracle text about jace", new CardImage("jaceHighresImg"), new Price(1, 2, 5)));
+        magicCardRepository.save(new MagicCard("1","Tarmogoyf", "some oracle text about tarmo", new CardImage("tarmoHighresImg"), "some set", new Price(10, 20, 15)));
+        magicCardRepository.save(new MagicCard("2","Jace, the Mindsculptor", "some oracle text about jace", new CardImage("jaceHighresImg"), "some set", new Price(1, 2, 5)));
 
         // When
 
@@ -45,7 +45,7 @@ class CardSearchControllerTest {
         // Then
 
         assertThat(response.getStatusCode(), is(HttpStatus.OK));
-        assertThat(response.getBody(),arrayContainingInAnyOrder(new MagicCard("1","Tarmogoyf", "some oracle text about tarmo", new CardImage("tarmoHighresImg"), new Price(10, 20, 15))));
+        assertThat(response.getBody(),arrayContainingInAnyOrder(new MagicCard("1","Tarmogoyf", "some oracle text about tarmo", new CardImage("tarmoHighresImg"), "some set", new Price(10, 20, 15))));
     }
 
 }

--- a/backend/src/test/java/de/christianporsch/backend/service/CardSearchServiceTest.java
+++ b/backend/src/test/java/de/christianporsch/backend/service/CardSearchServiceTest.java
@@ -26,7 +26,7 @@ class CardSearchServiceTest {
 
         // Given
 
-        List<MagicCard> magicCard = List.of(new MagicCard("1","Tarmogoyf", "some oracle text about tarmo", new CardImage("tarmoHighresImg"), new Price(10, 20, 15)));
+        List<MagicCard> magicCard = List.of(new MagicCard("1","Tarmogoyf", "some oracle text about tarmo", new CardImage("tarmoHighresImg"),"some set", new Price(10, 20, 15)));
         when(magicCardRepository.filterCardsByCardName("Tarmogoyf")).thenReturn(magicCard);
 
         // When
@@ -35,7 +35,7 @@ class CardSearchServiceTest {
 
         // Then
 
-        assertThat(magicCards, containsInAnyOrder(new MagicCard("1","Tarmogoyf", "some oracle text about tarmo", new CardImage("tarmoHighresImg"), new Price(10, 20, 15))));
+        assertThat(magicCards, containsInAnyOrder(new MagicCard("1","Tarmogoyf", "some oracle text about tarmo", new CardImage("tarmoHighresImg"),"some set", new Price(10, 20, 15))));
 
     }
 

--- a/frontend/src/hooks/useCardAddToPile.js
+++ b/frontend/src/hooks/useCardAddToPile.js
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+export default function useCardAddToPile() {
+
+
+    const addCardToPile = (id) => {
+        axios
+            .post('/api/cardsInPile/', {id})
+            .then(response => response.data)
+            .catch(error => console.log(error))
+    }
+
+    return {
+        addCardToPile
+    }
+
+}

--- a/frontend/src/hooks/useCardsInPile.js
+++ b/frontend/src/hooks/useCardsInPile.js
@@ -1,0 +1,19 @@
+import {useEffect, useState} from "react";
+import axios from "axios";
+
+export default function useCardsInPile(){
+
+    const [cardsInPile, setCardsInPile] = useState();
+
+    useEffect(() => {
+        axios
+            .get('/api/cardsInPile/60d2f120c76f8707f38e9a99')
+            .then(response => response.data)
+            .then(setCardsInPile)
+    }, [])
+
+    return {
+        cardsInPile
+    }
+
+}

--- a/frontend/src/pages/CardCollectionPage.js
+++ b/frontend/src/pages/CardCollectionPage.js
@@ -1,5 +1,6 @@
 import useCardsInPile from "../hooks/useCardsInPile";
-import styled from "styled-components/macro";
+import 'bootstrap/dist/css/bootstrap.min.css';
+import {Table} from "react-bootstrap";
 
 export default function CardCollectionPage() {
 
@@ -8,20 +9,36 @@ export default function CardCollectionPage() {
     return (
         <div>
             <h2>welcome to your collection</h2>
-            {cardsInPile && <section>
+            {cardsInPile && <Table striped bordered hover>
+                <thead className='text-center'>
+                    <tr>
+                        <th>
+                            cardname
+                        </th>
+                        <th>
+                            set
+                        </th>
+                        <th>
+                            amount
+                        </th>
+                    </tr>
+                </thead>
                 {cardsInPile.map(cardInPile => (
-                    <ImageAppearance key={cardInPile.id}src={cardInPile.image_uris?.normal} alt={cardInPile.name} />))}
-            </section>}
+                <tbody>
+                <tr>
+                    <td>
+                        {cardInPile.name}
+                    </td>
+                    <td>
+                        {cardInPile.set_name}
+                    </td>
+                    <td className='text-center'>
+                        {cardInPile.amount}
+                    </td>
+                </tr>
+                </tbody>))}
+            </Table>}
         </div>
     )
 }
 
-const ImageAppearance = styled.img`
-    
-        justify-content: space-evenly;
-        margin: 5px;
-        width: 150px;
-        height: auto;
-        border-radius: 7%;
-    
-    `

--- a/frontend/src/pages/CardCollectionPage.js
+++ b/frontend/src/pages/CardCollectionPage.js
@@ -1,8 +1,27 @@
+import useCardsInPile from "../hooks/useCardsInPile";
+import styled from "styled-components/macro";
 
-export default function CardCollectionPage(){
-    return(
+export default function CardCollectionPage() {
+
+    const {cardsInPile} = useCardsInPile();
+
+    return (
         <div>
             <h2>welcome to your collection</h2>
+            {cardsInPile && <section>
+                {cardsInPile.map(cardInPile => (
+                    <ImageAppearance key={cardInPile.id}src={cardInPile.image_uris?.normal} alt={cardInPile.name} />))}
+            </section>}
         </div>
     )
 }
+
+const ImageAppearance = styled.img`
+    
+        justify-content: space-evenly;
+        margin: 5px;
+        width: 150px;
+        height: auto;
+        border-radius: 7%;
+    
+    `

--- a/frontend/src/pages/SingleCardPage.js
+++ b/frontend/src/pages/SingleCardPage.js
@@ -3,6 +3,7 @@ import useCardId from "../hooks/useCardId";
 import styled from "styled-components/macro";
 import {Button} from "react-bootstrap";
 import useCardPrice from "../hooks/useCardPrice";
+import useCardAddToPile from "../hooks/useCardAddToPile";
 
 export default function SingleCardPage() {
 
@@ -10,8 +11,11 @@ export default function SingleCardPage() {
 
     const {card} = useCardId(id);
     const {cardPrice} = useCardPrice(id);
+    const {addCardToPile} = useCardAddToPile();
 
-    console.log(cardPrice);
+    const handleOnClick = () => {
+        addCardToPile(id);
+    }
 
     return (
         <div>
@@ -24,7 +28,7 @@ export default function SingleCardPage() {
                 <p>eur: {cardPrice.prices?.eur}</p>
                 <p>tix: {cardPrice.prices?.tix}</p>
             </SingleCardAppearance>
-            <Button variant='primary'>Add</Button>
+            <Button variant='primary' onClick={handleOnClick}>Add</Button>
         </div>
     )
 


### PR DESCRIPTION
What's in this feature:

-  Add User model, UserPileRepository, CardPileService and CardPileController to pass a user id in a get mapping to receive a list of magic cards owned by the user
- Add a post method to CardPileController and CardPileService to add magic cards to a hard coded user. Add MagicCardDto to pass only the card id from the FE
- Add useCardAddToPile hook for adding cards in the frontend
-  Add useCardsInPile and render it in CardCollectionPage 
-  Add MagicCardInPile model and MagicCardInPileRpository to seperate MagicCards in the multiverse and MagicCards in the pile of a user
- Modify addMagicCardToPile method to check if a card is already in pile or save it if not
-  Add parameter set_name to MagicCard and MagicCardInPile 
- Add alphabetical sorting in the CardCollectionController
- Add Bootstrap table in CardCollectionPage to give an overview of the user collection







